### PR TITLE
Linker fix when not using -load_all

### DIFF
--- a/libs/ObjectAL/Support/NSMutableArray+WeakReferences.m
+++ b/libs/ObjectAL/Support/NSMutableArray+WeakReferences.m
@@ -30,3 +30,8 @@
 }
 
 @end
+
+#define FIX_CATEGORY_BUG(name) @interface FIX_CATEGORY_BUG_##name @end @implementation FIX_CATEGORY_BUG_##name @end
+
+
+FIX_CATEGORY_BUG(NSMutableArray_WeakReferences);


### PR DESCRIPTION
Hi,

attached is a fix for linking problems when not using -load_all as "other linker flags" in your own app. See https://github.com/facebook/three20/pull/406 for more info. 

cheers,
Stephan
