### PR TITLE
Fixed a bug in queueBuffers: only the first buffer was queued

### DIFF
--- a/libs/ObjectAL/OpenAL/ALSource.m
+++ b/libs/ObjectAL/OpenAL/ALSource.m
@@ -1219,7 +1219,7 @@
 		int i = 0;
 		for(ALBuffer* buf in buffers)
 		{
-			bufferIds[i] = buf.bufferId;
+			bufferIds[i++] = buf.bufferId;
 		}
 		bool result = [ALWrapper sourceQueueBuffers:sourceId numBuffers:numBuffers bufferIds:bufferIds];
 		free(bufferIds);


### PR DESCRIPTION
Fixed a bug in queueBuffers: only the first buffer was queued, making the function useless
