### PR TITLE
New method in ALSource to queue a single buffer multiple times

### DIFF
--- a/libs/ObjectAL/OpenAL/ALSource.h
+++ b/libs/ObjectAL/OpenAL/ALSource.h
@@ -148,6 +148,14 @@
  */
 - (bool) queueBuffer:(ALBuffer*) buffer;
 
+/** Add a buffer to the buffer queue, repeating it multiple times.
+ *
+ * @param buffer the buffer to add to the queue.
+ * @param times the number of times to repeat the buffer in the queue.
+ * @return TRUE if the operation was successful.
+ */
+- (bool) queueBuffer:(ALBuffer*) bufferIn repeat: (int)times;
+
 /** Add buffers to the buffer queue.
  *
  * @param buffers the buffers to add to the queue.

--- a/libs/ObjectAL/OpenAL/ALSource.m
+++ b/libs/ObjectAL/OpenAL/ALSource.m
@@ -1200,6 +1200,32 @@
 	}
 }
 
+- (bool) queueBuffer:(ALBuffer*) bufferIn repeat: (int)times
+{
+	OPTIONALLY_SYNCHRONIZED(self)
+	{
+		if(self.suspended)
+		{
+			OAL_LOG_DEBUG(@"%@: Called mutator on suspended object", self);
+			return NO;
+		}
+		
+		if(AL_STATIC == self.state)
+		{
+			self.buffer = nil;
+		}
+		ALuint* bufferIds = (ALuint*)malloc(sizeof(ALuint) * times);
+		ALuint bufferId = bufferIn.bufferId;
+		for(int i = 0; i < times; i++)
+		{
+			bufferIds[i] = bufferId;
+		}
+		bool result = [ALWrapper sourceQueueBuffers:sourceId numBuffers:times bufferIds:bufferIds];
+		free(bufferIds);
+		return result;
+	}
+}
+
 - (bool) queueBuffers:(NSArray*) buffers
 {
 	OPTIONALLY_SYNCHRONIZED(self)


### PR DESCRIPTION
New method in ALSource - 'queueBuffer: repeat:'  to queue a single buffer multiple times.
