### PR TITLE
Fixes for 10.6.8 using Xcode 4.2

### DIFF
--- a/ObjectAL/ObjectAL/OpenAL/ALContext.m
+++ b/ObjectAL/ObjectAL/OpenAL/ALContext.m
@@ -52,7 +52,17 @@
 /** \endcond */
 
 
+@interface ALContext ()
+@property(nonatomic, readwrite, retain) ALDevice *device;
+
+@end
+
 @implementation ALContext
+@synthesize device;
+@synthesize sources;
+@synthesize listener;
+@synthesize context;
+@synthesize attributes;
 
 #pragma mark Object Management
 
@@ -234,11 +244,6 @@
 	return [ALWrapper getString:AL_VERSION];
 }
 
-@synthesize attributes;
-
-@synthesize context;
-
-@synthesize device;
 
 - (ALenum) distanceModel
 {
@@ -289,14 +294,15 @@
 	return [ALWrapper getSpaceSeparatedStringList:AL_EXTENSIONS];
 }
 
-@synthesize listener;
+
 
 - (NSString*) renderer
 {
 	return [ALWrapper getString:AL_RENDERER];
 }
 
-@synthesize sources;
+
+
 
 - (float) speedOfSound
 {


### PR DESCRIPTION
When trying to compile the master branch under 10.6.8 and Xcode 4.2, the following error prevented compilation:

```
ObjectAL-for-iPhone/ObjectAL/ObjectAL/OpenAL/ALContext.m:163:3: error: use of undeclared identifier 'device' [3]
```

Some rearranging of variable declarations and a private category solved this problem.  Please consider this pull request for those of us who, for some truly inane business reasons, must stay on 10.6.8.
