### PR TITLE
Add mute fuctions for one sound in OALSimpleAudio

### DIFF
--- a/ObjectAL/ObjectAL/OALSimpleAudio.h
+++ b/ObjectAL/ObjectAL/OALSimpleAudio.h
@@ -489,4 +489,20 @@ SYNTHESIZE_SINGLETON_FOR_CLASS_HEADER(OALSimpleAudio);
  */
 - (void) resetToDefault;
 
+/**
+ *  switch beteen mute and unmute.
+ *  @param filePath The path containing the sound data.
+ */
+- (void) switchMuteWithEffectName:(NSString*) filePath;
+/**
+ * only mute the effect.
+ * @param filePath The path containing the sound data.
+ */
+- (void) muteEffectWithName:(NSString*) filePath;
+/**
+ * only unmute the effect.
+ * @param filePath The path containing the sound data.
+ */
+- (void) unmuteEffectWithName:(NSString*) filePath;
+
 @end

--- a/ObjectAL/ObjectAL/OALSimpleAudio.m
+++ b/ObjectAL/ObjectAL/OALSimpleAudio.m
@@ -667,6 +667,57 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(OALSimpleAudio);
     [channel clearUnusedBuffers];
 }
 
+#pragma mark -
+#pragma mute Funtions
+- (void) switchMuteWithEffectName:(NSString*) filePath
+{
+	if(nil == filePath)
+	{
+		OAL_LOG_ERROR(@"filePath was NULL");
+	}
+    else
+    {
+        ALBuffer* buffer = [self internalPreloadEffect:filePath reduceToMono:NO];
+        if(nil != buffer)
+        {
+            [channel switchMuteWithEffectBuffer:buffer];
+        }
+    }
+}
+
+- (void) muteEffectWithName:(NSString*) filePath
+{
+	if(nil == filePath)
+	{
+		OAL_LOG_ERROR(@"filePath was NULL");
+	}
+    else
+    {
+        ALBuffer* buffer = [self internalPreloadEffect:filePath reduceToMono:NO];
+        if(nil != buffer)
+        {
+            [channel muteEffectWithBuffer:buffer];
+        }
+    }
+}
+
+- (void) unmuteEffectWithName:(NSString*) filePath
+{
+	if(nil == filePath)
+	{
+		OAL_LOG_ERROR(@"filePath was NULL");
+	}
+    else
+    {
+        ALBuffer* buffer = [self internalPreloadEffect:filePath reduceToMono:NO];
+        if(nil != buffer)
+        {
+            [channel unmuteEffectWithBuffer:buffer];
+        }
+    }
+}
+#pragma mark -
+
 
 #pragma mark Utility
 

--- a/ObjectAL/ObjectAL/OpenAL/ALChannelSource.h
+++ b/ObjectAL/ObjectAL/OpenAL/ALChannelSource.h
@@ -236,4 +236,20 @@
  */
 - (BOOL) removeBuffersNamed:(NSString*) name;
 
+/**
+ *  Mute one sound in the souce list
+ * @param effectSource the buffer of the sound.
+ */
+-(void) muteEffectWithBuffer:(ALBuffer *) effectSource;
+/**
+ *  Unmute one sound in the souce list
+ *  @param effectSource the buffer of the sound.
+ */
+-(void) unmuteEffectWithBuffer:(ALBuffer *) effectSource;
+/**
+ *  Mute and Unmute one sound in the source list
+ *  @param effectSource the buffer of the sound.
+ */
+-(void) switchMuteWithEffectBuffer:(ALBuffer *) effectSource;
+
 @end

--- a/ObjectAL/ObjectAL/OpenAL/ALChannelSource.m
+++ b/ObjectAL/ObjectAL/OpenAL/ALChannelSource.m
@@ -644,4 +644,55 @@ SYNTHESIZE_DELEGATE_PROPERTY(reverbObstruction, ReverbObstruction, float);
     return !playing;
 }
 
+#pragma mark -
+#pragma mute Function
+-(void) muteEffectWithBuffer:(ALBuffer *) effectSource
+{
+    OPTIONALLY_SYNCHRONIZED(sourcePool)
+	{
+        for(ALSource* source in sourcePool.sources)
+        {
+            if([source.buffer isEqual:effectSource])
+            {
+                source.volume = 0.0;
+            }
+        }
+    }
+}
+
+-(void) unmuteEffectWithBuffer:(ALBuffer *) effectSource
+{
+    OPTIONALLY_SYNCHRONIZED(sourcePool)
+	{
+        for(ALSource* source in sourcePool.sources)
+        {
+            if([source.buffer isEqual:effectSource])
+            {
+                source.volume = 1.0;
+            }
+        }
+    }
+}
+
+-(void) switchMuteWithEffectBuffer:(ALBuffer *) effectSource
+{
+    OPTIONALLY_SYNCHRONIZED(sourcePool)
+	{
+        for(ALSource* source in sourcePool.sources)
+        {
+            if([source.buffer isEqual:effectSource])
+            {
+                if (source.volume == 0.0)
+                {
+                    source.volume = 1.0;
+                }
+                else
+                {
+                    source.volume = 0.0;
+                }
+            }
+        }
+    }
+}
+
 @end


### PR DESCRIPTION
I'm developing a musical book, so didin't find functions to mute one sound using OALSimpleAudio, so I added tree functions to solve it.
## 

``` objective-c
  /*
     switch beteen mute and unmute.
     @param filePath The path containing the sound data.
 */
- (void) switchMuteWithEffectName:(NSString*) filePath;
```
## 

``` objective-c
/*
 only mute the effect.
 param filePath The path containing the sound data.
*/
- (void) muteEffectWithName:(NSString*) filePath;
```
## 

``` objective-c
/*
 only unmute the effect.
 param filePath The path containing the sound data.
*/
- (void) unmuteEffectWithName:(NSString*) filePath;
```
