### PR TITLE
Cancel delayed requests with ALSource object before deallocating

### DIFF
--- a/ObjectAL/ObjectAL (iOS)/OpenAL/ALSource.m
+++ b/ObjectAL/ObjectAL (iOS)/OpenAL/ALSource.m
@@ -183,6 +183,8 @@ static ALvoid alSourceNotification(ALuint sid, ALuint notificationID, ALvoid* us
 	[buffer performSelector:@selector(release) withObject:nil afterDelay:0.1];
 #endif
 	
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
+    
 	as_superdealloc();
 }
 


### PR DESCRIPTION
Crash may occur if delayed invocations happen after deallocation. In the setSuspended: method of ALSource, performSelector: withObject: afterDelay: is called. This is risky without cancelling all delayed calls in dealloc.
