### PR TITLE
Fixes #59. Change the loading order so that the AVAudioSession's category gets set ...

### DIFF
--- a/ObjectAL/ObjectAL (iOS)/OpenAL/ALDevice.m
+++ b/ObjectAL/ObjectAL (iOS)/OpenAL/ALDevice.m
@@ -48,8 +48,15 @@
 {
 	if(nil != (self = [super init]))
 	{
+		suspendHandler = [[OALSuspendHandler alloc] initWithTarget:nil selector:nil];
+		
+		contexts = [NSMutableArray newMutableArrayUsingWeakReferencesWithCapacity:5];
+			
+		[[OpenALManager sharedInstance] notifyDeviceInitializing:self];
+		[[OpenALManager sharedInstance] addSuspendListener:self];
+		
 		OAL_LOG_DEBUG(@"%@: Init device %@", self, deviceSpecifier);
-
+		
 		device = [ALWrapper openDevice:deviceSpecifier];
 		if(nil == device)
 		{
@@ -57,13 +64,6 @@
 			as_release(self);
 			return nil;
 		}
-
-		suspendHandler = [[OALSuspendHandler alloc] initWithTarget:nil selector:nil];
-		
-		contexts = [NSMutableArray newMutableArrayUsingWeakReferencesWithCapacity:5];
-			
-		[[OpenALManager sharedInstance] notifyDeviceInitializing:self];
-		[[OpenALManager sharedInstance] addSuspendListener:self];
 	}
 	return self;
 }


### PR DESCRIPTION
...before we open the ALCDevice. Fixes an issue on iOS 7 where calling alcOpenDevice before a category is set will silence other app's music as though the category were AVAudioSessionCategorySoloAmbient (which is the default category).
