### PR TITLE
Since ALSoundSources can be nil after init, they should only be added to the ALSoundSourcePool if they are not nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Thumbs.db
 *.orig
 *.xccheckout
 doxygen.config
+*.xcworkspace

--- a/ObjectAL/ObjectAL (iOS)/OpenAL/ALSoundSourcePool.m
+++ b/ObjectAL/ObjectAL (iOS)/OpenAL/ALSoundSourcePool.m
@@ -89,7 +89,10 @@
 {
 	OPTIONALLY_SYNCHRONIZED(self)
 	{
-		[sources addObject:source];
+		if(nil != source)
+		{
+			[sources addObject:source];
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes a crash.
