### PR TITLE
Fixed crash in ALSource setBuffer: if previous buffer gets deallocated

### DIFF
--- a/ObjectAL/ObjectAL/OpenAL/ALSource.m
+++ b/ObjectAL/ObjectAL/OpenAL/ALSource.m
@@ -210,10 +210,11 @@ initFailed:
 		}
 			
 		[self stop];
-
+        
+		[ALWrapper sourcei:sourceId parameter:AL_BUFFER value:(ALint)value.bufferId];
+        
         as_release(buffer);
 		buffer = as_retain(value);
-		[ALWrapper sourcei:sourceId parameter:AL_BUFFER value:(ALint)buffer.bufferId];
 	}
 }
 


### PR DESCRIPTION
Previously, calling ALSource's `-setBuffer:` would trigger an OpenAL error (and in my case, an EXC_BAD_ACCESS crash) _if that ALSource was maintaining the last reference to the old buffer_, and the old buffer got deallocated as a result.

This was because `-setBuffer:` was only switching the `AL_BUFFER` attached to the OpenAL source _after_ it had released the old ALBuffer object: but ALBuffer's `-dealloc` method calls `alDeleteBuffers`, which will fail in this circumstance because the old buffer is still attached to the source at that point.

This patch flips the order of things so that the source's `AL_BUFFER` is changed before the old buffer gets released.
