### PR TITLE
Workaround for issue 65: Audio does not resume after it has been suspend...

### DIFF
--- a/ObjectAL/ObjectAL/Session/OALSuspendHandler.m
+++ b/ObjectAL/ObjectAL/Session/OALSuspendHandler.m
@@ -218,7 +218,9 @@
 			{
 				if(nil != suspendStatusChangeTarget)
 				{
-					objc_msgSend(suspendStatusChangeTarget, suspendStatusChangeSelector, interruptLock);
+                    void (*suspendStatusChange)(id, SEL, bool);
+                    suspendStatusChange = (void (*)(id, SEL, bool))[suspendStatusChangeTarget methodForSelector:suspendStatusChangeSelector];
+                    suspendStatusChange(suspendStatusChangeTarget, suspendStatusChangeSelector, interruptLock);
 				}
 			}
 		}


### PR DESCRIPTION
Workaround for issue 65: Audio does not resume after it has been suspended by iOS (iPhone 5s & iOS 7.1)

https://github.com/kstenerud/ObjectAL-for-iPhone/issues/65
