### PR TITLE
Fix deallocation problem in suspendStatusChange call

### DIFF
--- a/ObjectAL/ObjectAL/Session/OALSuspendHandler.m
+++ b/ObjectAL/ObjectAL/Session/OALSuspendHandler.m
@@ -151,14 +151,17 @@
 			manualSuspendLock = value;
 			if(!interruptLock)
 			{
-				if(nil != suspendStatusChangeTarget)
-				{
-                    if([suspendStatusChangeTarget respondsToSelector:suspendStatusChangeSelector])
+                // Assign weak member var to a local var to prevent deallocation within this block
+                id localSuspendStatusChangeTarget = suspendStatusChangeTarget;
+                if(nil != localSuspendStatusChangeTarget)
+                {
+                    if([localSuspendStatusChangeTarget respondsToSelector:suspendStatusChangeSelector])
                     {
-                        id (*method)(id, SEL, bool)  = (id (*)(id, SEL, bool))[suspendStatusChangeTarget methodForSelector:suspendStatusChangeSelector];
-                        method(suspendStatusChangeTarget, suspendStatusChangeSelector, manualSuspendLock);
+                        id (*suspendStatusChange)(id, SEL, bool);
+                        suspendStatusChange = (id (*)(id, SEL, bool))[localSuspendStatusChangeTarget methodForSelector:suspendStatusChangeSelector];
+                        suspendStatusChange(localSuspendStatusChangeTarget, suspendStatusChangeSelector, manualSuspendLock);
                     }
-				}
+                }
 			}
 		}
 		
@@ -220,12 +223,18 @@
 			interruptLock = value;
 			if(!manualSuspendLock)
 			{
-				if(nil != suspendStatusChangeTarget)
-				{
-                    void (*suspendStatusChange)(id, SEL, bool);
-                    suspendStatusChange = (void (*)(id, SEL, bool))[suspendStatusChangeTarget methodForSelector:suspendStatusChangeSelector];
-                    suspendStatusChange(suspendStatusChangeTarget, suspendStatusChangeSelector, interruptLock);
-				}
+                // Assign weak member variable to a local var to prevent deallocation within this block
+                id localSuspendStatusChangeTarget = suspendStatusChangeTarget;
+
+                if(nil != localSuspendStatusChangeTarget)
+                {
+                    if([localSuspendStatusChangeTarget respondsToSelector:suspendStatusChangeSelector])
+                    {
+                        id (*suspendStatusChange)(id, SEL, bool);
+                        suspendStatusChange = (id (*)(id, SEL, bool))[localSuspendStatusChangeTarget methodForSelector:suspendStatusChangeSelector];
+                        suspendStatusChange(localSuspendStatusChangeTarget, suspendStatusChangeSelector, interruptLock);
+                    }
+                }
 			}
 		}
 		


### PR DESCRIPTION
...and also make coding styles match between calls in setManuallySuspended and setInterrupted to avoid confusion.

Because `suspendStatusChangeTarget` is declared as weak, it is possible that ARC will deallocate the object during the call to the selector, leading to a crash. The new code assigns `suspendStatusChangeTarget` to a (strong) local variable for the duration of the calling block in order to prevent its deletion - http://stackoverflow.com/questions/11899134/how-to-properly-address-weak-receiver-may-be-unpredictably-null-in-arc-mode

I am unable to create a scenario where the target is deleted during the call, so I'm not able to test the fix. The problem was brought to my attention by [megastep](https://github.com/megastep) in this conversation: https://github.com/croesus/ObjectAL-for-iPhone/commit/8a0ec71b963ba79fe814cbe669dccc19012ba211#commitcomment-9140967