### PR TITLE
[INTERRUPT] Fixes crashing interruption; `methodForSelector` --> `NSInvocation`

### DIFF
--- a/ObjectAL/ObjectAL/Session/OALSuspendHandler.m
+++ b/ObjectAL/ObjectAL/Session/OALSuspendHandler.m
@@ -230,9 +230,12 @@
                 {
                     if([localSuspendStatusChangeTarget respondsToSelector:suspendStatusChangeSelector])
                     {
-                        id (*suspendStatusChange)(id, SEL, bool);
-                        suspendStatusChange = (id (*)(id, SEL, bool))[localSuspendStatusChangeTarget methodForSelector:suspendStatusChangeSelector];
-                        suspendStatusChange(localSuspendStatusChangeTarget, suspendStatusChangeSelector, interruptLock);
+                        NSMethodSignature *signature = [[localSuspendStatusChangeTarget class] instanceMethodSignatureForSelector:suspendStatusChangeSelector];
+                        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+                        [invocation setTarget:localSuspendStatusChangeTarget];
+                        [invocation setSelector:suspendStatusChangeSelector];
+                        [invocation setArgument:&interruptLock atIndex:2];
+                        [invocation invoke];
                     }
                 }
 			}


### PR DESCRIPTION
Fixes crashing runtime call with the more robust NSInvocation.

Current crash repro steps:
1. Launch app
2. Play audio (I use simple engine to play music)
3. Receive an interrupt (I call my cellphone to repro)
4. Exception crash.