### PR TITLE
Fix pod spec for cocoapods 0.39.0

### DIFF
--- a/ObjectAL-for-iPhone.podspec
+++ b/ObjectAL-for-iPhone.podspec
@@ -12,5 +12,4 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.6'
   s.requires_arc = false
   s.ios.frameworks = 'OpenAL', 'AudioToolbox', 'AVFoundation'
-  s.header_mappings_dir = 'ObjectAL'
 end


### PR DESCRIPTION
With "header_mappings_dir" cocoa pods 0.39.0 now install headers to mimic a forlder structure inside "ObjectAL" folder. But headers of the project expect plain structure.

I only user of the cocoa pods and do not understand very well how it works internally. Also I was not test compatibility with previous versions of cocoapods, but I think that this pod should work as expected without the "header_mappings_dir" in pod spec.

Other pods also experiences problems, for ex: https://github.com/RestKit/RestKit/issues/2288