### PR TITLE
fixed deprecation warning

### DIFF
--- a/ObjectAL/ObjectAL/AudioTrack/OALAudioTrack.m
+++ b/ObjectAL/ObjectAL/AudioTrack/OALAudioTrack.m
@@ -936,7 +936,7 @@
 
 #if TARGET_OS_IPHONE
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void) audioPlayerBeginInterruption:(AVAudioPlayer*) playerIn
 {
 	if([delegate respondsToSelector:@selector(audioPlayerBeginInterruption:)])


### PR DESCRIPTION
noticed I was getting two warnings in xcode 7 for these deprecated functions. fixed the clang diagnostic push to include the correct parameter ("deprecated-declarations") for ignoring this type of deprecation.